### PR TITLE
Update media_player.py

### DIFF
--- a/custom_components/kef_connector/media_player.py
+++ b/custom_components/kef_connector/media_player.py
@@ -54,6 +54,7 @@ SOURCES = {
     "LSX2LT": ["wifi", "bluetooth", "tv", "optical", "usb"],
     "LS50W2": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
     "LS60": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
+    "XIO": ["wifi", "bluetooth", "tv", "optical"],
     "default": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog", "usb"],
 }
 


### PR DESCRIPTION
Add basic support for KEF XIO Soundbar.

As it has many extra options compared to the Stereo Speakers, will need to check how to implement the other features. For instance showing which codec is recognized and the many EQ/DSP options.