### PR TITLE
Add Config Flow UI with zeroconf discovery, failure tolerance, WiFi and codec sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,67 @@
-# 🏠️↔️🔉 Kef Connector
+# 🏠🔉 KEF Connector
 A Home Assistant integration for KEF speakers 🔊
 
-Kef Connector is compatible with LSX2LT, LSX2, LS50W2, LS60 and XIO Soundbar.
+KEF Connector is compatible with W2 Platform speakers:
+- LSX II  
+- LSX II LT  
+- LS50 Wireless II  
+- LS60 Wireless  
+- XIO Soundbar  
 
-- [🏠️↔️🔉 Kef Connector](#️️-kef-connector)
-  - [Installation and configuration](#installation-and-configuration)
-    - [⬇️ Installation](#️-installation)
-    - [🔧 Configuration](#-configuration)
-      - [📜 Platform configuration options](#-platform-configuration-options)
-      - [🧑‍🔬 Full configuration example](#-full-configuration-example)
+---
 
+## 📦 Installation
 
-## Installation and configuration
+This custom component is available via [HACS](https://hacs.xyz).  
+Search for **KEF Connector** in HACS and click **Download**. Restart Home Assistant to complete installation.
 
-### ⬇️ Installation
-This custom component is available on [HACS](https://hacs.xyz) !\
-You can also install it manually, but HACS is the recommended method (see bellow for "manual installation").
-Simply search for Kef Connector on HACS and clic download. Do not forget to restart home assistant and then follow the instructions in the [configuration](#-configuration) section.
+**Manual installation**  
+Copy the [`kef_connector`](custom_components/kef_connector) folder into your Home Assistant `config/custom_components` directory. Restart Home Assistant to activate the integration.
 
-**Manual Installation**\
-Copy the [kef_connector](custom_components/kef_connector) folder in your home assistant `config/custom_components` folder, and then follow the [configuration](#-configuration) section.
+---
 
-### 🔧 Configuration
+## ⚙️ Configuration
 
-In your `configuration.yaml` file, add the following :
+KEF Connector uses **Config Flow** and is configured entirely through the **Home Assistant UI**.  
+**YAML configuration is no longer supported.**
 
-```yaml
-media_player:
-  - platform: kef_connector
-    host: <IP-of-your-speakers>
-```
-⚠️ _Replace_ `<IP-of-your-speakers>` _with the correct IP._ 
+You can add the integration manually or wait for it to be discovered.
 
-More information on how to find the IP of your Kef speakers [here](https://github.com/N0ciple/pykefcontrol#-get-the-ip-address).
+### 🔍 Auto Discovery
+When your KEF speaker is discovered via Google Cast or AirPlay:
+- **Name**, **IP Address** and **Speaker Model** are automatically filled in.
+- You can review and adjust parameters before completing setup.
 
-#### 📜 Platform configuration options
+### 🛠 Manual Setup
+If your speaker isn’t discovered automatically, you can add it manually via the Integrations page.  
+You’ll be prompted to enter:
 
-Here is the list of the variables you can set if your `configuration.yaml` file.
+| Field                     | Description                                                                 |
+|--------------------------|-----------------------------------------------------------------------------|
+| **IP Address**            | IP of your KEF speaker (e.g. `192.168.1.42`)                                |
+| **Speaker Model**         | Choose from LSX II, LSX II LT, LS50 Wireless II, LS60 Wireless, or XIO      |
+| **Scan Interval**         | How often to poll the speaker when online (5–300 seconds)                   |
+| **Offline Retry Interval**| How often to check if an offline speaker is back online (30–600 seconds)    |
+| **Volume Step**           | Volume change per up/down command (0.01–0.10)                               |
+| **Maximum Volume**        | Safety limit for volume (0.1–1.0)                                           |
 
-| option           | required     | default value | comment|
-| ---------------- | ------------ | -------------|-------------------- |
-| `host`           | **Required** | `None`        | This should be a string in the form `www.xxx.yyy.zzz`, being the IP address of your speakers.|
-| `name`           | _Optional_   | _see comment_ | If you do not specify a `name`, the integration will fetch the name you set up on the KefConnect app for your speakers, if any. If you specify a `name` property, this name will be used instead.|
-| `maximum_volume` | _Optional_   | `1.0`         | This should be a float between 0 and 1. 0 is muted and 1 is maximum volume. Bear in mind that this option **does not** override the maximum volume set in the KefConnect app. It will prevent hass from setting a volume higher than `maximum_volume`|
-| `volume_step`    | _Optional_   | `0.03`        | This should be float bewteen 0 and 1 (however it is **not recommended** to set it higher than 0.1). This value is by how much volume will be changed when calling   `media_player.volume_up` or `media_player.volume_down` services, by clicking on ![volume_down_up](assets/images/volume_down_up.png) for example. |
-| `speaker_model`  | _Optional_   | _see comment_ | Write the model of your KEF speakers (either `LSX2`, `LSX2LT`, `LS50W2`, `LS60` or `XIO`). This allows Kef Connector to know which sources are available on your speakers. If you do not put `speaker_model` in your `configuration.yaml`, by default, all sources will be available on the entity, even though they are not physically present on your speakers (for example, there is no analog input on the LSX2LT). |
-#### 🧑‍🔬 Full configuration example
-This is just and example ! You can copy it but **at least** change the `host` value to the IP address of you speakers. More info on how to find the IP address [here](https://github.com/N0ciple/pykefcontrol#-get-the-ip-address).
-```yaml
-media_player:
-  - platform: kef_connector
-    host: 192.168.1.42
-    name: "My Kef Speakers"
-    maximum_volume: 0.7
-    volume_step: 0.02
-    speaker_model: LS50W2
-```
+All these settings can be changed later from the **Integration settings page**.
+
+---
+
+## 🔁 Migrating from YAML
+
+If you previously configured KEF Connector via `configuration.yaml`:
+- Remove any `kef_connector` entries from your YAML file.
+- Install or enable the integration via the UI:  
+  **Settings → Devices & Services → Add Integration → KEF Connector**
+- Recreate your previous settings during setup.  
+  All parameters are editable later from the Integration page — no restart required.
+
+---
+
+## 📚 Documentation & Support
+
+- [KEF Connector GitHub](https://github.com/N0ciple/hass-kef-connector)  
+- [Issue Tracker](https://github.com/N0ciple/hass-kef-connector/issues)  
+- [Library used: pykefcontrol](https://github.com/N0ciple/pykefcontrol)

--- a/custom_components/kef_connector/__init__.py
+++ b/custom_components/kef_connector/__init__.py
@@ -38,37 +38,16 @@ class KefHassAsyncConnector(KefAsyncConnector):
         host: str,
         session=None,
         hass: HomeAssistant | None = None,
+        model: str | None = None,
     ) -> None:
         """Initialize the KefAsyncConnector."""
-        super().__init__(host, session=session)
+        super().__init__(host, session=session, model=model)
         self.hass = hass
 
     async def resurect_session(self):
         """Resurect the session if it is closed."""
         if self._session is None:
             self._session = aiohttp_client.async_get_clientsession(self.hass)
-
-    async def get_request(self, path, roles="value"):
-        """Generic method to get data from any API path.
-
-        Args:
-            path: API path to query (e.g., "kef:eqProfile", "network:info")
-            roles: API roles parameter (default: "value")
-
-        Returns:
-            JSON response from API
-        """
-        payload = {
-            "path": path,
-            "roles": roles,
-        }
-        await self.resurect_session()
-        async with self._session.get(
-            "http://" + self.host + "/api/getData", params=payload
-        ) as response:
-            json_output = await response.json()
-
-        return json_output
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -85,8 +64,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create aiohttp session
     session = aiohttp_client.async_get_clientsession(hass)
 
+    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+
     # Create KEF speaker connector
-    speaker = KefHassAsyncConnector(host, session=session, hass=hass)
+    speaker = KefHassAsyncConnector(host, session=session, hass=hass, model=speaker_model)
 
     # Create coordinator
     coordinator = KefCoordinator(
@@ -95,6 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         name,
         scan_interval,
         offline_retry_interval,
+        speaker_model=speaker_model,
     )
 
     # Fetch initial data

--- a/custom_components/kef_connector/__init__.py
+++ b/custom_components/kef_connector/__init__.py
@@ -1,1 +1,137 @@
-"""The integration for KEF speakers."""
+"""The KEF Connector integration."""
+from __future__ import annotations
+
+import logging
+
+from pykefcontrol.kef_connector import KefAsyncConnector
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import (
+    CONF_MAX_VOLUME,
+    CONF_OFFLINE_RETRY_INTERVAL,
+    CONF_SCAN_INTERVAL,
+    CONF_SPEAKER_MODEL,
+    CONF_VOLUME_STEP,
+    DEFAULT_MAX_VOLUME,
+    DEFAULT_OFFLINE_RETRY_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_VOLUME_STEP,
+    DOMAIN,
+)
+from .coordinator import KefCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.SENSOR]
+
+
+class KefHassAsyncConnector(KefAsyncConnector):
+    """KefAsyncConnector with Home Assistant session management."""
+
+    def __init__(
+        self,
+        host: str,
+        session=None,
+        hass: HomeAssistant | None = None,
+    ) -> None:
+        """Initialize the KefAsyncConnector."""
+        super().__init__(host, session=session)
+        self.hass = hass
+
+    async def resurect_session(self):
+        """Resurect the session if it is closed."""
+        if self._session is None:
+            self._session = aiohttp_client.async_get_clientsession(self.hass)
+
+    async def get_request(self, path, roles="value"):
+        """Generic method to get data from any API path.
+
+        Args:
+            path: API path to query (e.g., "kef:eqProfile", "network:info")
+            roles: API roles parameter (default: "value")
+
+        Returns:
+            JSON response from API
+        """
+        payload = {
+            "path": path,
+            "roles": roles,
+        }
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+        return json_output
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up KEF Connector from a config entry."""
+    host = entry.data[CONF_HOST]
+    name = entry.data[CONF_NAME]
+
+    # Get options with defaults
+    scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    offline_retry_interval = entry.options.get(
+        CONF_OFFLINE_RETRY_INTERVAL, DEFAULT_OFFLINE_RETRY_INTERVAL
+    )
+
+    # Create aiohttp session
+    session = aiohttp_client.async_get_clientsession(hass)
+
+    # Create KEF speaker connector
+    speaker = KefHassAsyncConnector(host, session=session, hass=hass)
+
+    # Create coordinator
+    coordinator = KefCoordinator(
+        hass,
+        speaker,
+        name,
+        scan_interval,
+        offline_retry_interval,
+    )
+
+    # Fetch initial data
+    await coordinator.async_config_entry_first_refresh()
+
+    # Store coordinator in hass.data
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    # Setup platforms
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register options update listener
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    # Get coordinator
+    coordinator: KefCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Update intervals
+    scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    offline_retry_interval = entry.options.get(
+        CONF_OFFLINE_RETRY_INTERVAL, DEFAULT_OFFLINE_RETRY_INTERVAL
+    )
+    coordinator.update_intervals(scan_interval, offline_retry_interval)
+
+    # Request coordinator refresh with new interval
+    await coordinator.async_request_refresh()

--- a/custom_components/kef_connector/__init__.py
+++ b/custom_components/kef_connector/__init__.py
@@ -49,6 +49,10 @@ class KefHassAsyncConnector(KefAsyncConnector):
         if self._session is None:
             self._session = aiohttp_client.async_get_clientsession(self.hass)
 
+    async def close_session(self):
+        """Do not close the shared HA session — HA owns it."""
+        self._session = None  # Reset reference so resurect_session() refreshes it next call
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up KEF Connector from a config entry."""

--- a/custom_components/kef_connector/__init__.py
+++ b/custom_components/kef_connector/__init__.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create aiohttp session
     session = aiohttp_client.async_get_clientsession(hass)
 
-    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSXII").upper()
 
     # Create KEF speaker connector
     speaker = KefHassAsyncConnector(host, session=session, hass=hass, model=speaker_model)

--- a/custom_components/kef_connector/config_flow.py
+++ b/custom_components/kef_connector/config_flow.py
@@ -1,0 +1,404 @@
+"""Config flow for KEF Connector integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pykefcontrol.kef_connector import KefAsyncConnector
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components import zeroconf
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import aiohttp_client, selector
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import (
+    CONF_MAX_VOLUME,
+    CONF_OFFLINE_RETRY_INTERVAL,
+    CONF_SCAN_INTERVAL,
+    CONF_SPEAKER_MODEL,
+    CONF_VOLUME_STEP,
+    DEFAULT_MAX_VOLUME,
+    DEFAULT_OFFLINE_RETRY_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_VOLUME_STEP,
+    DOMAIN,
+    KEF_ZEROCONF_PREFIXES,
+    MAX_MAX_VOLUME,
+    MAX_OFFLINE_RETRY_INTERVAL,
+    MAX_SCAN_INTERVAL,
+    MAX_VOLUME_STEP,
+    MIN_MAX_VOLUME,
+    MIN_OFFLINE_RETRY_INTERVAL,
+    MIN_SCAN_INTERVAL,
+    MIN_VOLUME_STEP,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_model_from_discovery(discovery_info: zeroconf.ZeroconfServiceInfo) -> str:
+    """Parse KEF speaker model from zeroconf discovery info.
+
+    Google Cast names typically contain the model name.
+    Examples: "KEF LSX2", "KEF LSX2LT", "KEF LS60", etc.
+    """
+    # Check the service name first (this is where Google Cast puts the device name)
+    name = discovery_info.name.upper()
+
+    # Check for known models in order of specificity (most specific first)
+    if "LSX2LT" in name or "LSX II LT" in name or "LSX-II-LT" in name:
+        return "LSX2LT"
+    elif "LSX2" in name or "LSX II" in name or "LSX-II" in name:
+        return "LSX2"
+    elif "LS50W2" in name or "LS50 WIRELESS II" in name or "LS50-WIRELESS-II" in name:
+        return "LS50W2"
+    elif "LS60" in name:
+        return "LS60"
+    elif "XIO" in name:
+        return "XIO"
+
+    # Also check properties dict in case it's there
+    properties = discovery_info.properties
+    if properties:
+        # Check for model in common property keys
+        for key in ["md", "model", "device_model"]:
+            if key in properties:
+                model_value = properties[key].upper()
+                if "LSX2LT" in model_value:
+                    return "LSX2LT"
+                elif "LSX2" in model_value:
+                    return "LSX2"
+                elif "LS50W2" in model_value:
+                    return "LS50W2"
+                elif "LS60" in model_value:
+                    return "LS60"
+                elif "XIO" in model_value:
+                    return "XIO"
+
+    # Default to LSX2 if we can't detect
+    _LOGGER.debug(
+        "Could not detect KEF model from discovery info (name=%s), defaulting to LSX2",
+        discovery_info.name
+    )
+    return "LSX2"
+
+
+def is_kef_speaker(discovery_info: zeroconf.ZeroconfServiceInfo) -> bool:
+    """Check if discovered device is a KEF speaker based on zeroconf name.
+
+    KEF speakers advertise with specific Google Cast name patterns.
+    Returns True if the device appears to be a KEF speaker.
+    """
+    name_upper = discovery_info.name.upper()
+    return any(name_upper.startswith(prefix) for prefix in KEF_ZEROCONF_PREFIXES)
+
+
+async def validate_connection(
+    hass: HomeAssistant, host: str
+) -> dict[str, Any]:
+    """Validate the connection to a KEF speaker.
+
+    Returns dict with:
+        - mac_address: for unique_id
+        - speaker_name: for friendly name
+        - speaker_model: for device info and source list
+    """
+    session = aiohttp_client.async_get_clientsession(hass)
+    connector = KefAsyncConnector(host, session=session)
+
+    try:
+        # Get speaker information
+        mac_address = await connector.mac_address
+        speaker_name = await connector.speaker_name
+
+        # Validate we got valid data
+        if not mac_address or not speaker_name:
+            raise ValueError("Unable to retrieve speaker information")
+
+        # Note: speaker_model is not available from the API
+        # We'll default to "LSX2" which is the most common model
+        return {
+            "mac_address": format_mac(mac_address),
+            "speaker_name": speaker_name,
+            "speaker_model": "LSX2",
+        }
+    except Exception as err:
+        _LOGGER.error("Error connecting to KEF speaker at %s: %s", host, err)
+        raise
+
+
+class KefConnectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for KEF Connector."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovered_host: str | None = None
+        self._discovered_name: str | None = None
+        self._detected_model: str | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step - manual IP entry."""
+        errors = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+
+            try:
+                info = await validate_connection(self.hass, host)
+            except Exception:
+                errors["base"] = "cannot_connect"
+            else:
+                # Set unique ID to prevent duplicates
+                await self.async_set_unique_id(info["mac_address"])
+                self._abort_if_unique_id_configured()
+
+                # Get user-selected model and options
+                speaker_model = user_input.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+                options = {
+                    CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                    CONF_OFFLINE_RETRY_INTERVAL: user_input.get(
+                        CONF_OFFLINE_RETRY_INTERVAL, DEFAULT_OFFLINE_RETRY_INTERVAL
+                    ),
+                    CONF_VOLUME_STEP: user_input.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+                    CONF_MAX_VOLUME: user_input.get(CONF_MAX_VOLUME, DEFAULT_MAX_VOLUME),
+                }
+
+                return self.async_create_entry(
+                    title=info["speaker_name"],
+                    data={
+                        CONF_HOST: host,
+                        CONF_NAME: info["speaker_name"],
+                        CONF_SPEAKER_MODEL: speaker_model,
+                    },
+                    options=options,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required(CONF_HOST): str,
+                vol.Required(CONF_SPEAKER_MODEL, default="LSX2"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=["LSX2", "LSX2LT", "LS50W2", "LS60", "XIO"],
+                        translation_key="speaker_model",
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+                vol.Required(
+                    CONF_SCAN_INTERVAL,
+                    default=DEFAULT_SCAN_INTERVAL,
+                ): vol.All(vol.Coerce(int), vol.Range(
+                    min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL
+                )),
+                vol.Required(
+                    CONF_OFFLINE_RETRY_INTERVAL,
+                    default=DEFAULT_OFFLINE_RETRY_INTERVAL,
+                ): vol.All(vol.Coerce(int), vol.Range(
+                    min=MIN_OFFLINE_RETRY_INTERVAL, max=MAX_OFFLINE_RETRY_INTERVAL
+                )),
+                vol.Required(
+                    CONF_VOLUME_STEP,
+                    default=DEFAULT_VOLUME_STEP,
+                ): vol.All(vol.Coerce(float), vol.Range(
+                    min=MIN_VOLUME_STEP, max=MAX_VOLUME_STEP
+                )),
+                vol.Required(
+                    CONF_MAX_VOLUME,
+                    default=DEFAULT_MAX_VOLUME,
+                ): vol.All(vol.Coerce(float), vol.Range(
+                    min=MIN_MAX_VOLUME, max=MAX_MAX_VOLUME
+                )),
+            }),
+            errors=errors,
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: zeroconf.ZeroconfServiceInfo
+    ) -> FlowResult:
+        """Handle zeroconf discovery."""
+        host = discovery_info.host
+
+        # Filter: Only process KEF speakers
+        if not is_kef_speaker(discovery_info):
+            _LOGGER.debug(
+                "Ignoring non-KEF Google Cast device '%s' at %s",
+                discovery_info.name,
+                host
+            )
+            return self.async_abort(reason="not_kef_device")
+
+        # Try to get speaker info
+        try:
+            info = await validate_connection(self.hass, host)
+        except Exception:
+            return self.async_abort(reason="cannot_connect")
+
+        # Set unique ID and abort if already configured
+        await self.async_set_unique_id(info["mac_address"])
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
+        # Parse model from discovery info (Google Cast name)
+        self._detected_model = parse_model_from_discovery(discovery_info)
+        _LOGGER.info(
+            "Detected KEF model '%s' for speaker '%s' from zeroconf discovery",
+            self._detected_model,
+            info["speaker_name"]
+        )
+
+        # Store discovered info for confirmation step
+        self._discovered_host = host
+        self._discovered_name = info["speaker_name"]
+
+        # Set suggested name in context for the UI
+        self.context["title_placeholders"] = {
+            "name": info["speaker_name"],
+        }
+
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm discovery."""
+        if user_input is not None:
+            # User confirmed, get full speaker info
+            try:
+                info = await validate_connection(self.hass, self._discovered_host)
+            except Exception:
+                return self.async_abort(reason="cannot_connect")
+
+            # Use the user-selected model
+            speaker_model = user_input.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+
+            # Extract options for initial setup
+            options = {
+                CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                CONF_OFFLINE_RETRY_INTERVAL: user_input.get(
+                    CONF_OFFLINE_RETRY_INTERVAL, DEFAULT_OFFLINE_RETRY_INTERVAL
+                ),
+                CONF_VOLUME_STEP: user_input.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP),
+                CONF_MAX_VOLUME: user_input.get(CONF_MAX_VOLUME, DEFAULT_MAX_VOLUME),
+            }
+
+            return self.async_create_entry(
+                title=info["speaker_name"],
+                data={
+                    CONF_HOST: self._discovered_host,
+                    CONF_NAME: info["speaker_name"],
+                    CONF_SPEAKER_MODEL: speaker_model,
+                },
+                options=options,
+            )
+
+        # Show form with speaker model selection (using detected model as default)
+        detected_model = self._detected_model or "LSX2"
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            data_schema=vol.Schema({
+                vol.Required(CONF_SPEAKER_MODEL, default=detected_model): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=["LSX2", "LSX2LT", "LS50W2", "LS60", "XIO"],
+                        translation_key="speaker_model",
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+                vol.Required(
+                    CONF_SCAN_INTERVAL,
+                    default=DEFAULT_SCAN_INTERVAL,
+                ): vol.All(vol.Coerce(int), vol.Range(
+                    min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL
+                )),
+                vol.Required(
+                    CONF_OFFLINE_RETRY_INTERVAL,
+                    default=DEFAULT_OFFLINE_RETRY_INTERVAL,
+                ): vol.All(vol.Coerce(int), vol.Range(
+                    min=MIN_OFFLINE_RETRY_INTERVAL, max=MAX_OFFLINE_RETRY_INTERVAL
+                )),
+                vol.Required(
+                    CONF_VOLUME_STEP,
+                    default=DEFAULT_VOLUME_STEP,
+                ): vol.All(vol.Coerce(float), vol.Range(
+                    min=MIN_VOLUME_STEP, max=MAX_VOLUME_STEP
+                )),
+                vol.Required(
+                    CONF_MAX_VOLUME,
+                    default=DEFAULT_MAX_VOLUME,
+                ): vol.All(vol.Coerce(float), vol.Range(
+                    min=MIN_MAX_VOLUME, max=MAX_MAX_VOLUME
+                )),
+            }),
+            description_placeholders={
+                "name": self._discovered_name,
+                "host": self._discovered_host,
+            },
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> KefConnectorOptionsFlow:
+        """Get the options flow for this handler."""
+        return KefConnectorOptionsFlow(config_entry)
+
+
+class KefConnectorOptionsFlow(config_entries.OptionsFlow):
+    """Handle options flow for KEF Connector."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        # config_entry is set by the flow manager as a property
+        # We just need to accept it as a parameter
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_SCAN_INTERVAL,
+                    default=self.config_entry.options.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(
+                    min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL
+                )),
+                vol.Required(
+                    CONF_OFFLINE_RETRY_INTERVAL,
+                    default=self.config_entry.options.get(
+                        CONF_OFFLINE_RETRY_INTERVAL, DEFAULT_OFFLINE_RETRY_INTERVAL
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(
+                    min=MIN_OFFLINE_RETRY_INTERVAL, max=MAX_OFFLINE_RETRY_INTERVAL
+                )),
+                vol.Required(
+                    CONF_VOLUME_STEP,
+                    default=self.config_entry.options.get(
+                        CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP
+                    ),
+                ): vol.All(vol.Coerce(float), vol.Range(
+                    min=MIN_VOLUME_STEP, max=MAX_VOLUME_STEP
+                )),
+                vol.Required(
+                    CONF_MAX_VOLUME,
+                    default=self.config_entry.options.get(
+                        CONF_MAX_VOLUME, DEFAULT_MAX_VOLUME
+                    ),
+                ): vol.All(vol.Coerce(float), vol.Range(
+                    min=MIN_MAX_VOLUME, max=MAX_MAX_VOLUME
+                )),
+            }),
+        )

--- a/custom_components/kef_connector/config_flow.py
+++ b/custom_components/kef_connector/config_flow.py
@@ -44,20 +44,20 @@ def parse_model_from_discovery(discovery_info: zeroconf.ZeroconfServiceInfo) -> 
     """Parse KEF speaker model from zeroconf discovery info.
 
     Google Cast names typically contain the model name.
-    Examples: "KEF LSX2", "KEF LSX2LT", "KEF LS60", etc.
+    Examples: "KEF LSXII", "KEF LSXIILT", "KEF LS60Wireless", etc.
     """
     # Check the service name first (this is where Google Cast puts the device name)
     name = discovery_info.name.upper()
 
     # Check for known models in order of specificity (most specific first)
-    if "LSX2LT" in name or "LSX II LT" in name or "LSX-II-LT" in name:
-        return "LSX2LT"
-    elif "LSX2" in name or "LSX II" in name or "LSX-II" in name:
-        return "LSX2"
-    elif "LS50W2" in name or "LS50 WIRELESS II" in name or "LS50-WIRELESS-II" in name:
-        return "LS50W2"
+    if "LSX II LT" in name or "LSX-II-LT" in name or "LSXIILT" in name:
+        return "LSXIILT"
+    elif "LSX II" in name or "LSX-II" in name or "LSXII" in name:
+        return "LSXII"
+    elif "LS50 WIRELESS II" in name or "LS50-WIRELESS-II" in name or "LS50WII" in name:
+        return "LS50WII"
     elif "LS60" in name:
-        return "LS60"
+        return "LS60Wireless"
     elif "XIO" in name:
         return "XIO"
 
@@ -68,23 +68,23 @@ def parse_model_from_discovery(discovery_info: zeroconf.ZeroconfServiceInfo) -> 
         for key in ["md", "model", "device_model"]:
             if key in properties:
                 model_value = properties[key].upper()
-                if "LSX2LT" in model_value:
-                    return "LSX2LT"
-                elif "LSX2" in model_value:
-                    return "LSX2"
-                elif "LS50W2" in model_value:
-                    return "LS50W2"
+                if "LSXIILT" in model_value or "LSX II LT" in model_value:
+                    return "LSXIILT"
+                elif "LSXII" in model_value or "LSX II" in model_value:
+                    return "LSXII"
+                elif "LS50WII" in model_value or "LS50 WIRELESS II" in model_value:
+                    return "LS50WII"
                 elif "LS60" in model_value:
-                    return "LS60"
+                    return "LS60Wireless"
                 elif "XIO" in model_value:
                     return "XIO"
 
-    # Default to LSX2 if we can't detect
+    # Default to LSXII if we can't detect
     _LOGGER.debug(
-        "Could not detect KEF model from discovery info (name=%s), defaulting to LSX2",
+        "Could not detect KEF model from discovery info (name=%s), defaulting to LSXII",
         discovery_info.name
     )
-    return "LSX2"
+    return "LSXII"
 
 
 def is_kef_speaker(discovery_info: zeroconf.ZeroconfServiceInfo) -> bool:
@@ -120,11 +120,11 @@ async def validate_connection(
             raise ValueError("Unable to retrieve speaker information")
 
         # Note: speaker_model is not available from the API
-        # We'll default to "LSX2" which is the most common model
+        # We'll default to "LSXII" which is the most common model
         return {
             "mac_address": format_mac(mac_address),
             "speaker_name": speaker_name,
-            "speaker_model": "LSX2",
+            "speaker_model": "LSXII",
         }
     except Exception as err:
         _LOGGER.error("Error connecting to KEF speaker at %s: %s", host, err)
@@ -161,7 +161,7 @@ class KefConnectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 # Get user-selected model and options
-                speaker_model = user_input.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+                speaker_model = user_input.get(CONF_SPEAKER_MODEL, "LSXII").upper()
                 options = {
                     CONF_SCAN_INTERVAL: user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
                     CONF_OFFLINE_RETRY_INTERVAL: user_input.get(
@@ -185,9 +185,9 @@ class KefConnectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema({
                 vol.Required(CONF_HOST): str,
-                vol.Required(CONF_SPEAKER_MODEL, default="LSX2"): selector.SelectSelector(
+                vol.Required(CONF_SPEAKER_MODEL, default="LSXII"): selector.SelectSelector(
                     selector.SelectSelectorConfig(
-                        options=["LSX2", "LSX2LT", "LS50W2", "LS60", "XIO"],
+                        options=["LSXII", "LSXIILT", "LS50WII", "LS60Wireless", "XIO"],
                         translation_key="speaker_model",
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )
@@ -276,7 +276,7 @@ class KefConnectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="cannot_connect")
 
             # Use the user-selected model
-            speaker_model = user_input.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+            speaker_model = user_input.get(CONF_SPEAKER_MODEL, "LSXII").upper()
 
             # Extract options for initial setup
             options = {
@@ -299,13 +299,13 @@ class KefConnectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         # Show form with speaker model selection (using detected model as default)
-        detected_model = self._detected_model or "LSX2"
+        detected_model = self._detected_model or "LSXII"
         return self.async_show_form(
             step_id="zeroconf_confirm",
             data_schema=vol.Schema({
                 vol.Required(CONF_SPEAKER_MODEL, default=detected_model): selector.SelectSelector(
                     selector.SelectSelectorConfig(
-                        options=["LSX2", "LSX2LT", "LS50W2", "LS60", "XIO"],
+                        options=["LSXII", "LSXIILT", "LS50WII", "LS60Wireless", "XIO"],
                         translation_key="speaker_model",
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )

--- a/custom_components/kef_connector/const.py
+++ b/custom_components/kef_connector/const.py
@@ -19,6 +19,7 @@ DEFAULT_OFFLINE_RETRY_INTERVAL: Final = 60  # seconds
 DEFAULT_VOLUME_STEP: Final = 0.05
 DEFAULT_MAX_VOLUME: Final = 1.0
 DEFAULT_SPEAKER_MODEL: Final = "LSX2"
+DEFAULT_FAILURE_THRESHOLD: Final = 3  # consecutive failures before marking offline
 
 # Validation ranges
 MIN_SCAN_INTERVAL: Final = 5

--- a/custom_components/kef_connector/const.py
+++ b/custom_components/kef_connector/const.py
@@ -18,7 +18,7 @@ DEFAULT_SCAN_INTERVAL: Final = 10  # seconds
 DEFAULT_OFFLINE_RETRY_INTERVAL: Final = 60  # seconds
 DEFAULT_VOLUME_STEP: Final = 0.05
 DEFAULT_MAX_VOLUME: Final = 1.0
-DEFAULT_SPEAKER_MODEL: Final = "LSX2"
+DEFAULT_SPEAKER_MODEL: Final = "LSXII"
 DEFAULT_FAILURE_THRESHOLD: Final = 3  # consecutive failures before marking offline
 
 # Validation ranges
@@ -33,29 +33,29 @@ MAX_MAX_VOLUME: Final = 1.0
 
 # Speaker models and their available sources
 SOURCES: Final = {
-    "LSX2": ["wifi", "bluetooth", "tv", "optical", "analog", "usb"],
-    "LSX2LT": ["wifi", "bluetooth", "tv", "optical", "usb"],
-    "LS50W2": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
-    "LS60": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
+    "LSXII": ["wifi", "bluetooth", "tv", "optical", "analog", "usb"],
+    "LSXIILT": ["wifi", "bluetooth", "tv", "optical", "usb"],
+    "LS50WII": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
+    "LS60Wireless": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
     "XIO": ["wifi", "bluetooth", "tv", "optical"],
 }
 
 # KEF speaker model prefixes for zeroconf filtering
 # Order matters: check more specific patterns first (LSX-II-LT- before LSX-II-)
 KEF_ZEROCONF_PREFIXES: Final = [
-    "LSX-II-LT-",      # LSX2LT model
-    "LSX-II-",         # LSX2 model (check after LSX-II-LT-)
-    "LS50-WIRELESS-II-",  # LS50W2 model
-    "LS60-",           # LS60 model
+    "LSX-II-LT-",      # LSXIILT model
+    "LSX-II-",         # LSXII model (check after LSX-II-LT-)
+    "LS50-WIRELESS-II-",  # LS50WII model
+    "LS60-",           # LS60Wireless model
     "XIO-",            # XIO model
 ]
 
 # Speaker model display names
 MODEL_NAMES: Final = {
-    "LSX2": "LSX II",
-    "LSX2LT": "LSX II LT",
-    "LS50W2": "LS50 Wireless II",
-    "LS60": "LS60 Wireless",
+    "LSXII": "LSX II",
+    "LSXIILT": "LSX II LT",
+    "LS50WII": "LS50 Wireless II",
+    "LS60Wireless": "LS60 Wireless",
     "XIO": "XIO",
 }
 

--- a/custom_components/kef_connector/const.py
+++ b/custom_components/kef_connector/const.py
@@ -1,0 +1,68 @@
+"""Constants for the KEF Connector integration."""
+from __future__ import annotations
+
+from typing import Final
+
+# Domain
+DOMAIN: Final = "kef_connector"
+
+# Configuration keys
+CONF_SCAN_INTERVAL: Final = "scan_interval"
+CONF_OFFLINE_RETRY_INTERVAL: Final = "offline_retry_interval"
+CONF_MAX_VOLUME: Final = "maximum_volume"
+CONF_VOLUME_STEP: Final = "volume_step"
+CONF_SPEAKER_MODEL: Final = "speaker_model"
+
+# Defaults
+DEFAULT_SCAN_INTERVAL: Final = 10  # seconds
+DEFAULT_OFFLINE_RETRY_INTERVAL: Final = 60  # seconds
+DEFAULT_VOLUME_STEP: Final = 0.05
+DEFAULT_MAX_VOLUME: Final = 1.0
+DEFAULT_SPEAKER_MODEL: Final = "LSX2"
+
+# Validation ranges
+MIN_SCAN_INTERVAL: Final = 5
+MAX_SCAN_INTERVAL: Final = 300
+MIN_OFFLINE_RETRY_INTERVAL: Final = 30
+MAX_OFFLINE_RETRY_INTERVAL: Final = 600
+MIN_VOLUME_STEP: Final = 0.01
+MAX_VOLUME_STEP: Final = 0.10
+MIN_MAX_VOLUME: Final = 0.1
+MAX_MAX_VOLUME: Final = 1.0
+
+# Speaker models and their available sources
+SOURCES: Final = {
+    "LSX2": ["wifi", "bluetooth", "tv", "optical", "analog", "usb"],
+    "LSX2LT": ["wifi", "bluetooth", "tv", "optical", "usb"],
+    "LS50W2": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
+    "LS60": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
+    "XIO": ["wifi", "bluetooth", "tv", "optical"],
+}
+
+# KEF speaker model prefixes for zeroconf filtering
+# Order matters: check more specific patterns first (LSX-II-LT- before LSX-II-)
+KEF_ZEROCONF_PREFIXES: Final = [
+    "LSX-II-LT-",      # LSX2LT model
+    "LSX-II-",         # LSX2 model (check after LSX-II-LT-)
+    "LS50-WIRELESS-II-",  # LS50W2 model
+    "LS60-",           # LS60 model
+    "XIO-",            # XIO model
+]
+
+# Speaker model display names
+MODEL_NAMES: Final = {
+    "LSX2": "LSX II",
+    "LSX2LT": "LSX II LT",
+    "LS50W2": "LS50 Wireless II",
+    "LS60": "LS60 Wireless",
+    "XIO": "XIO",
+}
+
+# Unique ID prefix for entity registry
+UNIQUE_ID_PREFIX: Final = "KEF_SPEAKER"
+
+# Zeroconf discovery
+ZEROCONF_TYPE: Final = "_http._tcp.local."
+
+# Device info
+MANUFACTURER: Final = "KEF"

--- a/custom_components/kef_connector/coordinator.py
+++ b/custom_components/kef_connector/coordinator.py
@@ -25,14 +25,19 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         name: str,
         scan_interval: int,
         offline_retry_interval: int,
+        speaker_model: str = "LSX2",
     ) -> None:
         """Initialize the coordinator."""
         self.speaker = speaker
         self.name = name
+        self.speaker_model = speaker_model.upper()
         self.normal_interval = timedelta(seconds=scan_interval)
         self.offline_interval = timedelta(seconds=offline_retry_interval)
         self._is_offline = False
         self._error_logged = False
+        self._consecutive_failures = 0
+        self._failure_threshold = 3  # Number of consecutive failures before switching to offline mode
+        self._last_successful_data: dict[str, Any] | None = None
 
         super().__init__(
             hass,
@@ -69,10 +74,10 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 song_position = await self.speaker.song_status
 
             # Get codec info (available on models with HDMI/TV inputs)
-            codec_info = await self._get_audio_codec_information()
+            codec_info = await self.speaker.get_audio_codec_information()
 
             # Get WiFi signal strength
-            wifi_info = await self._get_wifi_information()
+            wifi_info = await self.speaker.get_wifi_information()
 
             # Speaker is online - reset offline state
             if self._is_offline:
@@ -85,7 +90,11 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # Return to normal polling interval
                 self.update_interval = self.normal_interval
 
-            return {
+            # Reset failure counter on successful update
+            self._consecutive_failures = 0
+
+            # Cache successful data for use during transient failures
+            data = {
                 "volume": volume,
                 "status": status,
                 "source": source,
@@ -99,6 +108,7 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "song_position": song_position,
                 # Codec information (may be None on some sources/models)
                 "audio_codec": codec_info.get("codec"),
+                "audio_codec_raw": codec_info.get("codec"),
                 "sample_rate": codec_info.get("sampleFrequency"),
                 "stream_channels": codec_info.get("streamChannels"),
                 "audio_channels": codec_info.get("nrAudioChannels"),
@@ -109,90 +119,51 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "wifi_frequency": wifi_info.get("frequency"),
                 "wifi_bssid": wifi_info.get("bssid"),
             }
+            self._last_successful_data = data
+            return data
 
         except Exception as err:
-            # Speaker is offline or unreachable
-            if not self._is_offline:
-                # First time seeing this error - log it and switch to offline mode
-                _LOGGER.warning(
-                    "KEF speaker '%s' is offline or unreachable: %s. "
-                    "Will retry every %d seconds until it comes back online",
+            # Increment consecutive failure counter
+            self._consecutive_failures += 1
+
+            # Check if we've reached the threshold for marking as offline
+            if self._consecutive_failures >= self._failure_threshold:
+                # Now consider the speaker truly offline
+                if not self._is_offline:
+                    # First time marking as offline - log warning and switch to slow polling
+                    _LOGGER.warning(
+                        "KEF speaker '%s' is offline or unreachable after %d consecutive failures: %s. "
+                        "Will retry every %d seconds until it comes back online",
+                        self.name,
+                        self._consecutive_failures,
+                        err,
+                        self.offline_interval.total_seconds(),
+                    )
+                    self._is_offline = True
+                    self._error_logged = True
+                    # Switch to slower retry interval
+                    self.update_interval = self.offline_interval
+
+                # Raise UpdateFailed to mark entity as unavailable
+                raise UpdateFailed(f"Error communicating with KEF speaker: {err}") from err
+
+            else:
+                # Still within tolerance - log as debug and return cached data
+                _LOGGER.debug(
+                    "KEF speaker '%s' connection attempt %d/%d failed: %s. "
+                    "Using cached data and retrying at normal interval",
                     self.name,
+                    self._consecutive_failures,
+                    self._failure_threshold,
                     err,
-                    self.offline_interval.total_seconds(),
                 )
-                self._is_offline = True
-                self._error_logged = True
-                # Switch to slower retry interval
-                self.update_interval = self.offline_interval
 
-            # Raise UpdateFailed to mark entity as unavailable
-            raise UpdateFailed(f"Error communicating with KEF speaker: {err}") from err
+                # If we have cached data, return it to keep entity available
+                if self._last_successful_data is not None:
+                    return self._last_successful_data
 
-    async def _get_audio_codec_information(self) -> dict[str, Any]:
-        """Get audio codec information from player data.
-
-        Returns dict with codec, sample rate, and channel information.
-        """
-        try:
-            # Get player data from speaker
-            player_data = await self.speaker._get_player_data()
-
-            codec_dict = {}
-            active_resource = (
-                player_data.get("trackRoles", {})
-                .get("mediaData", {})
-                .get("activeResource", {})
-            )
-
-            if active_resource:
-                codec_dict["codec"] = active_resource.get("codec")
-                codec_dict["sampleFrequency"] = active_resource.get("sampleFrequency")
-                codec_dict["streamSampleRate"] = active_resource.get("streamSampleRate")
-                codec_dict["streamChannels"] = active_resource.get("streamChannels")
-                codec_dict["nrAudioChannels"] = active_resource.get("nrAudioChannels")
-
-            # Get streaming service ID from mediaRoles
-            media_roles = player_data.get("mediaRoles", {})
-            meta_data = media_roles.get("mediaData", {}).get("metaData", {})
-            if meta_data:
-                codec_dict["serviceID"] = meta_data.get("serviceID")
-
-            return codec_dict
-        except Exception:
-            # Silently return empty dict if codec info not available
-            return {}
-
-    async def _get_wifi_information(self) -> dict[str, Any]:
-        """Get WiFi information from speaker.
-
-        Returns dict with WiFi signal strength, SSID, frequency, and BSSID.
-        """
-        try:
-            # Get network info from speaker
-            network_data = await self.speaker.get_request(
-                "network:info", roles="value"
-            )
-
-            wifi_dict = {}
-            network_info = (
-                network_data[0].get("networkInfo", {})
-                if network_data
-                else {}
-            )
-
-            if network_info:
-                wireless = network_info.get("wireless", {})
-                if wireless:
-                    wifi_dict["signalLevel"] = wireless.get("signalLevel")
-                    wifi_dict["ssid"] = wireless.get("ssid")
-                    wifi_dict["frequency"] = wireless.get("frequency")
-                    wifi_dict["bssid"] = wireless.get("bssid")
-
-            return wifi_dict
-        except Exception:
-            # Silently return empty dict if WiFi info not available
-            return {}
+                # No cached data yet (first poll ever failed) - have to mark unavailable
+                raise UpdateFailed(f"Initial connection failed (attempt {self._consecutive_failures}/{self._failure_threshold}): {err}") from err
 
     def update_intervals(self, scan_interval: int, offline_retry_interval: int) -> None:
         """Update the polling intervals from options."""

--- a/custom_components/kef_connector/coordinator.py
+++ b/custom_components/kef_connector/coordinator.py
@@ -1,0 +1,206 @@
+"""DataUpdateCoordinator for KEF Connector."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from pykefcontrol.kef_connector import KefAsyncConnector
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Class to manage fetching KEF speaker data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        speaker: KefAsyncConnector,
+        name: str,
+        scan_interval: int,
+        offline_retry_interval: int,
+    ) -> None:
+        """Initialize the coordinator."""
+        self.speaker = speaker
+        self.name = name
+        self.normal_interval = timedelta(seconds=scan_interval)
+        self.offline_interval = timedelta(seconds=offline_retry_interval)
+        self._is_offline = False
+        self._error_logged = False
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_{name}",
+            update_interval=self.normal_interval,
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from KEF speaker.
+
+        Returns dict with all speaker state information.
+        Raises UpdateFailed if speaker is unreachable.
+        """
+        try:
+            # Get all speaker state in one update cycle
+            volume = await self.speaker.volume
+            status = await self.speaker.status
+            source = await self.speaker.source
+            is_playing = (
+                await self.speaker.is_playing
+                if source in ["wifi", "bluetooth"]
+                else False
+            )
+
+            # Get media info (may return empty dict if nothing playing)
+            media_info = await self.speaker.get_song_information()
+
+            # Get song playback info if playing
+            song_length = None
+            song_position = None
+            if is_playing:
+                song_length = await self.speaker.song_length
+                song_position = await self.speaker.song_status
+
+            # Get codec info (available on models with HDMI/TV inputs)
+            codec_info = await self._get_audio_codec_information()
+
+            # Get WiFi signal strength
+            wifi_info = await self._get_wifi_information()
+
+            # Speaker is online - reset offline state
+            if self._is_offline:
+                _LOGGER.info(
+                    "KEF speaker '%s' is back online",
+                    self.name,
+                )
+                self._is_offline = False
+                self._error_logged = False
+                # Return to normal polling interval
+                self.update_interval = self.normal_interval
+
+            return {
+                "volume": volume,
+                "status": status,
+                "source": source,
+                "is_playing": is_playing,
+                "media_title": media_info.get("title"),
+                "media_artist": media_info.get("artist"),
+                "media_album": media_info.get("album"),
+                "media_album_artist": media_info.get("album_artist"),
+                "media_image_url": media_info.get("cover_url"),
+                "song_length": song_length,
+                "song_position": song_position,
+                # Codec information (may be None on some sources/models)
+                "audio_codec": codec_info.get("codec"),
+                "sample_rate": codec_info.get("sampleFrequency"),
+                "stream_channels": codec_info.get("streamChannels"),
+                "audio_channels": codec_info.get("nrAudioChannels"),
+                "streaming_service": codec_info.get("serviceID"),
+                # WiFi information
+                "wifi_signal_strength": wifi_info.get("signalLevel"),
+                "wifi_ssid": wifi_info.get("ssid"),
+                "wifi_frequency": wifi_info.get("frequency"),
+                "wifi_bssid": wifi_info.get("bssid"),
+            }
+
+        except Exception as err:
+            # Speaker is offline or unreachable
+            if not self._is_offline:
+                # First time seeing this error - log it and switch to offline mode
+                _LOGGER.warning(
+                    "KEF speaker '%s' is offline or unreachable: %s. "
+                    "Will retry every %d seconds until it comes back online",
+                    self.name,
+                    err,
+                    self.offline_interval.total_seconds(),
+                )
+                self._is_offline = True
+                self._error_logged = True
+                # Switch to slower retry interval
+                self.update_interval = self.offline_interval
+
+            # Raise UpdateFailed to mark entity as unavailable
+            raise UpdateFailed(f"Error communicating with KEF speaker: {err}") from err
+
+    async def _get_audio_codec_information(self) -> dict[str, Any]:
+        """Get audio codec information from player data.
+
+        Returns dict with codec, sample rate, and channel information.
+        """
+        try:
+            # Get player data from speaker
+            player_data = await self.speaker._get_player_data()
+
+            codec_dict = {}
+            active_resource = (
+                player_data.get("trackRoles", {})
+                .get("mediaData", {})
+                .get("activeResource", {})
+            )
+
+            if active_resource:
+                codec_dict["codec"] = active_resource.get("codec")
+                codec_dict["sampleFrequency"] = active_resource.get("sampleFrequency")
+                codec_dict["streamSampleRate"] = active_resource.get("streamSampleRate")
+                codec_dict["streamChannels"] = active_resource.get("streamChannels")
+                codec_dict["nrAudioChannels"] = active_resource.get("nrAudioChannels")
+
+            # Get streaming service ID from mediaRoles
+            media_roles = player_data.get("mediaRoles", {})
+            meta_data = media_roles.get("mediaData", {}).get("metaData", {})
+            if meta_data:
+                codec_dict["serviceID"] = meta_data.get("serviceID")
+
+            return codec_dict
+        except Exception:
+            # Silently return empty dict if codec info not available
+            return {}
+
+    async def _get_wifi_information(self) -> dict[str, Any]:
+        """Get WiFi information from speaker.
+
+        Returns dict with WiFi signal strength, SSID, frequency, and BSSID.
+        """
+        try:
+            # Get network info from speaker
+            network_data = await self.speaker.get_request(
+                "network:info", roles="value"
+            )
+
+            wifi_dict = {}
+            network_info = (
+                network_data[0].get("networkInfo", {})
+                if network_data
+                else {}
+            )
+
+            if network_info:
+                wireless = network_info.get("wireless", {})
+                if wireless:
+                    wifi_dict["signalLevel"] = wireless.get("signalLevel")
+                    wifi_dict["ssid"] = wireless.get("ssid")
+                    wifi_dict["frequency"] = wireless.get("frequency")
+                    wifi_dict["bssid"] = wireless.get("bssid")
+
+            return wifi_dict
+        except Exception:
+            # Silently return empty dict if WiFi info not available
+            return {}
+
+    def update_intervals(self, scan_interval: int, offline_retry_interval: int) -> None:
+        """Update the polling intervals from options."""
+        self.normal_interval = timedelta(seconds=scan_interval)
+        self.offline_interval = timedelta(seconds=offline_retry_interval)
+
+        # Update current interval based on current state
+        if self._is_offline:
+            self.update_interval = self.offline_interval
+        else:
+            self.update_interval = self.normal_interval

--- a/custom_components/kef_connector/coordinator.py
+++ b/custom_components/kef_connector/coordinator.py
@@ -25,7 +25,7 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         name: str,
         scan_interval: int,
         offline_retry_interval: int,
-        speaker_model: str = "LSX2",
+        speaker_model: str = "LSXII",
     ) -> None:
         """Initialize the coordinator."""
         self.speaker = speaker

--- a/custom_components/kef_connector/coordinator.py
+++ b/custom_components/kef_connector/coordinator.py
@@ -73,8 +73,12 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 song_length = await self.speaker.song_length
                 song_position = await self.speaker.song_status
 
-            # Get codec info (available on models with HDMI/TV inputs)
-            codec_info = await self.speaker.get_audio_codec_information()
+            # Get codec info (XIO only — other models only support LPCM)
+            codec_info = (
+                await self.speaker.get_audio_codec_information()
+                if self.speaker_model == "XIO"
+                else {}
+            )
 
             # Get WiFi signal strength
             wifi_info = await self.speaker.get_wifi_information()

--- a/custom_components/kef_connector/coordinator.py
+++ b/custom_components/kef_connector/coordinator.py
@@ -70,8 +70,11 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             song_length = None
             song_position = None
             if is_playing:
-                song_length = await self.speaker.song_length
-                song_position = await self.speaker.song_status
+                try:
+                    song_length = await self.speaker.song_length
+                    song_position = await self.speaker.song_status
+                except Exception:
+                    pass
 
             # Get codec info (XIO only — other models only support LPCM)
             codec_info = (

--- a/custom_components/kef_connector/coordinator.py
+++ b/custom_components/kef_connector/coordinator.py
@@ -123,6 +123,12 @@ class KefCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data
 
         except Exception as err:
+            # Reset the aiohttp session so the next poll starts with a clean
+            # connection pool. A failed/interrupted request can leave the
+            # session's C-level state corrupted; resurect_session() will create
+            # a fresh one on the next call.
+            await self.speaker.close_session()
+
             # Increment consecutive failure counter
             self._consecutive_failures += 1
 

--- a/custom_components/kef_connector/manifest.json
+++ b/custom_components/kef_connector/manifest.json
@@ -1,16 +1,21 @@
 {
   "domain": "kef_connector",
-  "name": "Kef Connector",
+  "name": "KEF Connector",
   "codeowners": [
-    "@n0ciple"
+    "@n0ciple",
+    "@danielpetrovic"
   ],
-  "config_flow": false,
+  "config_flow": true,
   "documentation": "https://github.com/N0ciple/hass-kef-connector",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "issue_tracker":"https://github.com/N0ciple/hass-kef-connector/issues",
+  "issue_tracker": "https://github.com/N0ciple/hass-kef-connector/issues",
   "requirements": [
     "pykefcontrol==0.9.1"
   ],
-  "version":"0.6.0"
+  "version": "1.0.0",
+  "zeroconf": [
+    "_airplay._tcp.local.",
+    "_googlecast._tcp.local."
+  ]
 }

--- a/custom_components/kef_connector/manifest.json
+++ b/custom_components/kef_connector/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/N0ciple/hass-kef-connector/issues",
   "requirements": [
-    "pykefcontrol==0.9.1"
+    "pykefcontrol>=0.9.1"
   ],
   "version": "1.0.0",
   "zeroconf": [

--- a/custom_components/kef_connector/manifest.json
+++ b/custom_components/kef_connector/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/N0ciple/hass-kef-connector/issues",
   "requirements": [
-    "pykefcontrol>=0.9.1"
+    "pykefcontrol>=0.9.2"
   ],
   "version": "1.0.0",
   "zeroconf": [

--- a/custom_components/kef_connector/manifest.json
+++ b/custom_components/kef_connector/manifest.json
@@ -1,16 +1,21 @@
 {
   "domain": "kef_connector",
-  "name": "Kef Connector",
+  "name": "KEF Connector",
   "codeowners": [
-    "@n0ciple"
+    "@n0ciple",
+    "@danielpetrovic"
   ],
-  "config_flow": false,
+  "config_flow": true,
   "documentation": "https://github.com/N0ciple/hass-kef-connector",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "issue_tracker":"https://github.com/N0ciple/hass-kef-connector/issues",
+  "issue_tracker": "https://github.com/N0ciple/hass-kef-connector/issues",
   "requirements": [
-    "pykefcontrol==0.9.3"
+    "pykefcontrol>=0.9.3"
   ],
-  "version":"0.6.5"
+  "version": "1.0.0",
+  "zeroconf": [
+    "_airplay._tcp.local.",
+    "_googlecast._tcp.local."
+  ]
 }

--- a/custom_components/kef_connector/media_player.py
+++ b/custom_components/kef_connector/media_player.py
@@ -248,6 +248,10 @@ class KefSpeaker(CoordinatorEntity, MediaPlayerEntity):
             # Split codec to get only the codec part (before " - ")
             codec_name = audio_codec.split(" - ")[0] if " - " in audio_codec else audio_codec
 
+            # Strip "Dolby " prefix from PCM (but NOT from "Dolby Digital" or "Dolby Digital Plus")
+            if codec_name == "Dolby PCM":
+                codec_name = "PCM"
+
             # Build codec string with channel format
             codec_display = codec_name
             if channel_format:
@@ -319,6 +323,10 @@ class KefSpeaker(CoordinatorEntity, MediaPlayerEntity):
             codec_name = codec_full.split(" - ")[0] if " - " in codec_full else codec_full
             virtualizer_name = codec_full.split(" - ")[1] if " - " in codec_full else "Direct"
 
+            # Strip "Dolby " prefix from PCM (but NOT from "Dolby Digital" or "Dolby Digital Plus")
+            if codec_name == "Dolby PCM":
+                codec_name = "PCM"
+
             # Helper to format channel count
             def format_channels(count):
                 channel_map = {2: "2.0", 6: "5.1", 8: "5.1.2"}
@@ -330,19 +338,36 @@ class KefSpeaker(CoordinatorEntity, MediaPlayerEntity):
                 channel_format = format_channels(stream_channels)
                 attrs["audio_codec"] = f"{codec_name} {channel_format}" if channel_format else codec_name
             else:
+                # Fallback: just codec name without channel count
                 attrs["audio_codec"] = codec_name
 
-            # Add virtualizer with playback channel format
-            audio_channels = self.coordinator.data.get("audio_channels")
-            if audio_channels is not None:
-                channel_format = format_channels(audio_channels)
+            # Add virtualizer with channel format
+            # For Direct mode: use INPUT channels (stream_channels), fallback to OUTPUT channels
+            # For virtualizer modes: use fixed 8 channels (5.1.2) since API returns garbage
+            if virtualizer_name == "Direct":
+                # Direct mode - use input channels, fallback to output if input unknown
+                channels = stream_channels
+                if channels is None or channels == 0:
+                    # Fallback to playback channels (e.g., Dolby Atmos with unknown input)
+                    channels = self.coordinator.data.get("audio_channels")
+            else:
+                # Virtualizer active - hardcode to 8 (5.1.2) for XIO
+                channels = 8
+
+            if channels is not None and channels > 0:
+                channel_format = format_channels(channels)
                 attrs["audio_virtualizer"] = f"{virtualizer_name} {channel_format}" if channel_format else virtualizer_name
             else:
+                # Fallback: just virtualizer name without channel count
                 attrs["audio_virtualizer"] = virtualizer_name
 
         # Sample rate
         if self.coordinator.data.get("sample_rate"):
-            attrs["sample_rate"] = self.coordinator.data["sample_rate"]
+            attrs["audio_sample_rate"] = self.coordinator.data["sample_rate"]
+
+        # Raw codec (unparsed)
+        if self.coordinator.data.get("audio_codec_raw"):
+            attrs["audio_codec_raw"] = self.coordinator.data["audio_codec_raw"]
 
         # Streaming service ID (e.g., "airplay", "spotify")
         if self.coordinator.data.get("streaming_service"):

--- a/custom_components/kef_connector/media_player.py
+++ b/custom_components/kef_connector/media_player.py
@@ -1,18 +1,15 @@
+"""Media player platform for KEF Connector integration."""
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
 import functools
 import logging
 
-from pykefcontrol.kef_connector import KefAsyncConnector
-import voluptuous as vol
-
 from homeassistant.components.media_player import (
-    PLATFORM_SCHEMA,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -23,98 +20,30 @@ from homeassistant.const import (
     STATE_PLAYING,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-import homeassistant.helpers.aiohttp_client as hass_aiohttp
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
-
-# from homeassistant.helpers.entity_component import EntityComponent
-# from homeassistant.helpers.entity_platform import AddEntitiesCallback
-# from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import homeassistant.util.dt as dt_util
+
+from .const import (
+    CONF_MAX_VOLUME,
+    CONF_SPEAKER_MODEL,
+    CONF_VOLUME_STEP,
+    DEFAULT_MAX_VOLUME,
+    DEFAULT_VOLUME_STEP,
+    DOMAIN,
+    MANUFACTURER,
+    MODEL_NAMES,
+    SOURCES,
+    UNIQUE_ID_PREFIX,
+)
+from .coordinator import KefCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_MAX_VOLUME = "maximum_volume"
-CONF_VOLUME_STEP = "volume_step"
-CONF_SPEAKER_MODEL = "speaker_model"
-
-DEFAULT_NAME = "DEFAULT_KEFSPEAKER"
-DEFAULT_MAX_VOLUME = 1
-DEFAULT_VOLUME_STEP = 0.03
-DEFAULT_SPEAKER_MODEL = "default"
-
-SCAN_INTERVAL = timedelta(seconds=10)
-
-
-DOMAIN = "kef_connector"
-
-SOURCES = {
-    "LSX2": ["wifi", "bluetooth", "tv", "optical", "analog", "usb"],
-    "LSX2LT": ["wifi", "bluetooth", "tv", "optical", "usb"],
-    "LS50W2": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
-    "LS60": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog"],
-    "XIO": ["wifi", "bluetooth", "tv", "optical"],
-    "default": ["wifi", "bluetooth", "tv", "optical", "coaxial", "analog", "usb"],
-}
-
-UNIQUE_ID_PREFIX = "KEF_SPEAKER"
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_MAX_VOLUME, default=DEFAULT_MAX_VOLUME): cv.small_float,
-        vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): cv.small_float,
-        vol.Optional(CONF_SPEAKER_MODEL, default=DEFAULT_SPEAKER_MODEL): cv.string,
-    }
-)
-
-
-def migrate_old_unique_ids(hass: HomeAssistant):
-    """Migrate old unique ids to new format."""
-    registry = er.async_get(hass)
-    for entity in registry.entities.values():
-        if entity.platform == DOMAIN:
-            entity_mac_address = entity.unique_id.split("_")[-1]
-            if entity.unique_id == "KEFLS50W2_" + entity_mac_address:
-                _LOGGER.warning(
-                    "Kef Connector found an entity with an old unique_id: %s. It will automatically migrate it to the new unique_id scheme. The entity is : %s",
-                    entity.unique_id,
-                    entity,
-                )
-                registry.async_update_entity(
-                    entity.entity_id,
-                    new_unique_id=f"{UNIQUE_ID_PREFIX}_{format_mac(entity_mac_address)}",
-                )
-
-
-# Create new class from KefAsyncConnector to override the
-# resurect_session method, so that i uses the function
-# async_get_clientsession
-class KefHassAsyncConnector(KefAsyncConnector):
-    """KefAsyncConnector with resurect_session method."""
-
-    def __init__(
-        self,
-        host,
-        session=None,
-        hass: HomeAssistant | None = None,
-        model=None,
-    ) -> None:
-        """Initialize the KefAsyncConnector."""
-
-        super().__init__(host, session=session, model=model)
-        self.hass = hass
-
-    async def resurect_session(self):
-        """Resurect the session if it is closed."""
-        if self._session is None:
-            self._session = hass_aiohttp.async_get_clientsession(self.hass)
-
 
 # Decorator to delay the update of home assistant UI
-# since the speaker does not update imediately is internal state
+# since the speaker does not update immediately its internal state
 def delay_update(delay):
     """Delay the update of home assistant UI."""
 
@@ -126,7 +55,7 @@ def delay_update(delay):
             # Sleep the set delay
             await asyncio.sleep(delay)
             # Trigger an update
-            self.async_schedule_update_ha_state(True)
+            await self.coordinator.async_request_refresh()
             return output
 
         return wrapper
@@ -134,135 +63,131 @@ def delay_update(delay):
     return inner_function
 
 
-async def async_setup_platform(
-    hass: HomeAssistant | None,
-    config,
-    async_add_entities,
-    discovery_info=None,
-):
-    """Set up platform kef_connector."""
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up KEF Connector media player from config entry."""
+    coordinator: KefCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    # Get variables from configuration
-    host = config[CONF_HOST]
-    name = config[CONF_NAME]
-    max_volume = config[CONF_MAX_VOLUME]
-    volume_step = config[CONF_VOLUME_STEP]
-    speaker_model = config[CONF_SPEAKER_MODEL]
+    # Get config
+    name = entry.data[CONF_NAME]
+    host = entry.data[CONF_HOST]
+    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSX2").upper()
 
-    # make sure the speaker model is in uppercase
-    speaker_model = speaker_model.upper()
+    # Get options with defaults
+    max_volume = entry.options.get(CONF_MAX_VOLUME, DEFAULT_MAX_VOLUME)
+    volume_step = entry.options.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
 
-    # get session
-    session = hass_aiohttp.async_create_clientsession(hass)
+    # Get sources for this model
+    sources = SOURCES.get(speaker_model, SOURCES["LSX2"])
 
-    if speaker_model not in SOURCES:
-        sources = SOURCES["default"]
-        _LOGGER.warning(
-            "Kef Speaker model %s is unknown. Using default sources. Please make sure the model is either LSX2, LSX2LT, LS50W2 or LS60",
-            speaker_model,
-        )
-    else:
-        sources = SOURCES[speaker_model]
+    # Get unique_id from coordinator speaker
+    mac_address = format_mac(await coordinator.speaker.mac_address)
+    unique_id = f"{UNIQUE_ID_PREFIX}_{mac_address}"
 
-    # Pass model to the connector if explicitly configured
-    if speaker_model == "default":
-        speaker_model = None
-        _LOGGER.warning(
-            "No speaker_model configured. The model will be auto-detected via an API call. "
-            "Please set speaker_model in your configuration as this will become mandatory in a future version."
-        )
-
-    _LOGGER.debug(
-        "Setting up %s with host: %s, name: %s, sources: %s",
-        DOMAIN,
-        host,
-        name,
-        sources,
+    # Create entity
+    entity = KefSpeaker(
+        coordinator=coordinator,
+        name=name,
+        unique_id=unique_id,
+        speaker_model=speaker_model,
+        sources=sources,
+        max_volume=max_volume,
+        volume_step=volume_step,
+        host=host,
     )
 
-    # Migrate old unique ids starting with "KEFLS50W2_" to the new format "KEF_SPEAKER_" + mac_address
-    migrate_old_unique_ids(hass)
-
-    media_player = KefSpeaker(
-        host, name, max_volume, volume_step, sources, session, hass, speaker_model
-    )
-
-    async_add_entities([media_player], update_before_add=True)
-
-    return True
+    async_add_entities([entity])
 
 
-class KefSpeaker(MediaPlayerEntity):
+class KefSpeaker(CoordinatorEntity, MediaPlayerEntity):
     """Media player implementation for KEF Speakers."""
 
     def __init__(
         self,
-        host,
-        name,
-        max_volume,
-        volume_step,
-        sources,
-        session,
-        hass: HomeAssistant | None,
-        model=None,
+        coordinator: KefCoordinator,
+        name: str,
+        unique_id: str,
+        speaker_model: str,
+        sources: list[str],
+        max_volume: float,
+        volume_step: float,
+        host: str,
     ) -> None:
         """Initialize the media player."""
-        super().__init__()
-        self._speaker = KefHassAsyncConnector(host, session=session, hass=hass, model=model)
-        if name != DEFAULT_NAME:
-            self._name = name
-        else:
-            self._name = None
-        self._max_volume = max_volume
-        self._volume_step = volume_step * 100
+        super().__init__(coordinator)
+
+        # Store config
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+        self._speaker_model = speaker_model
         self._sources = sources
-        # Default previous source to wifi at component creation
+        self._max_volume = max_volume
+        self._volume_step = volume_step * 100  # Convert to 0-100 range
+
+        # State tracking
         self._previous_source = "wifi"
 
-        # Variables to update in async_update
-        self._volume = None
-        self._state = None
-        self._muted = None
-        self._source = None
-        self._attr_media_artist = None
-        self._attr_media_album_name = None
-        self._attr_media_title = None
-        self._attr_media_position = None
-        self._attr_media_duration = None
-        self._attr_media_position_updated_at = None
-        self._attr_unique_id = None
-        self._attr_media_image_url = None
-        self._attr_media_image_remotely_accessible = False
+        # Device info
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, unique_id)},
+            "name": name,
+            "manufacturer": MANUFACTURER,
+            "model": MODEL_NAMES.get(speaker_model, f"KEF {speaker_model}"),
+            "connections": {("ip", host)},
+        }
 
     @property
-    def should_poll(self):
-        """Push an update after each command."""
-        return True
-
-    @property
-    def name(self):
-        """Return the name of the device."""
-        return self._name
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
 
     @property
     def state(self):
         """Return the state of the device."""
-        return self._state
+        if not self.available:
+            return None
+
+        data = self.coordinator.data
+
+        if data["status"] == "standby":
+            return STATE_OFF
+        elif data["source"] in ["wifi", "bluetooth"]:
+            if data["is_playing"]:
+                return STATE_PLAYING
+            elif data["media_title"] is not None:
+                return STATE_PAUSED
+            else:
+                return STATE_IDLE
+        else:
+            return STATE_ON
 
     @property
     def volume_level(self):
         """Volume level of the media player (0..1)."""
-        return self._volume
+        if not self.available:
+            return None
+        return self.coordinator.data["volume"] / 100
 
     @property
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
-        return self._muted
+        if not self.available:
+            return None
+        return self.coordinator.data["volume"] == 0
 
     @property
     def source(self):
         """Name of the current input source."""
-        return self._source
+        if not self.available:
+            return None
+        source = self.coordinator.data["source"]
+        # Store valid sources as previous source
+        if source in self._sources:
+            self._previous_source = source
+        return source
 
     @property
     def source_list(self):
@@ -275,34 +200,95 @@ class KefSpeaker(MediaPlayerEntity):
         return "mdi:speaker-wireless"
 
     @property
-    def unique_id(self):
-        """Return the device unique id."""
-        return self._attr_unique_id
-
-    @property
     def media_image_url(self) -> str | None:
         """Image url of current playing media."""
-        return self._attr_media_image_url
+        if not self.available:
+            return None
+
+        # No album art for non-streaming sources (TV, Optical, etc.)
+        source = self.coordinator.data.get("source")
+        if source in ["tv", "optical", "analog", "coaxial", "usb"]:
+            return None
+
+        return self.coordinator.data.get("media_image_url")
 
     @property
     def media_artist(self):
         """Artist of current playing media, music track only."""
-        return self._attr_media_artist
+        if not self.available:
+            return None
+        return self.coordinator.data.get("media_artist")
 
     @property
     def media_album_name(self):
         """Album name of current playing media, music track only."""
-        return self._attr_media_album_name
+        if not self.available:
+            return None
+        return self.coordinator.data.get("media_album")
 
     @property
     def media_title(self):
         """Title of current playing media."""
-        return self._attr_media_title
+        if not self.available:
+            return None
+
+        title = self.coordinator.data.get("media_title")
+        source = self.coordinator.data.get("source")
+        audio_codec = self.coordinator.data.get("audio_codec")
+
+        # Append codec to title for TV/HDMI sources
+        if source in ["tv", "optical", "analog", "coaxial", "usb"] and audio_codec:
+            # Format channel count (2→"2.0", 6→"5.1", 8→"5.1.2")
+            stream_channels = self.coordinator.data.get("stream_channels")
+            channel_format = None
+            if stream_channels is not None and stream_channels > 0:
+                channel_map = {2: "2.0", 6: "5.1", 8: "5.1.2"}
+                channel_format = channel_map.get(stream_channels, str(stream_channels))
+
+            # Split codec to get only the codec part (before " - ")
+            codec_name = audio_codec.split(" - ")[0] if " - " in audio_codec else audio_codec
+
+            # Build codec string with channel format
+            codec_display = codec_name
+            if channel_format:
+                codec_display = f"{codec_name} {channel_format}"
+
+            if title:
+                return f"{title} - {codec_display}"
+            return codec_display
+
+        return title
+
+    @property
+    def media_content_type(self):
+        """Content type of current playing media."""
+        if not self.available:
+            return None
+
+        source = self.coordinator.data.get("source")
+        # Return "music" for streaming sources to enable artist/album display
+        if source in ["wifi", "bluetooth"]:
+            return "music"
+        # Return "channel" for TV/HDMI sources
+        elif source in ["tv", "optical", "analog", "coaxial", "usb"]:
+            return "channel"
+        return None
 
     @property
     def media_position(self):
         """Position of current playing media in seconds."""
-        return self._attr_media_position
+        if not self.available:
+            return None
+        song_position = self.coordinator.data.get("song_position")
+        return int(song_position / 1000) if song_position is not None else None
+
+    @property
+    def media_duration(self):
+        """Duration of current playing media in seconds."""
+        if not self.available:
+            return None
+        song_length = self.coordinator.data.get("song_length")
+        return int(song_length / 1000) if song_length is not None else None
 
     @property
     def media_position_updated_at(self):
@@ -310,8 +296,63 @@ class KefSpeaker(MediaPlayerEntity):
 
         Returns value from homeassistant.util.dt.utcnow().
         """
+        if not self.available:
+            return None
+        # Return current time if playing, None otherwise
+        if self.state == STATE_PLAYING:
+            return dt_util.utcnow()
+        return None
 
-        return self._attr_media_position_updated_at
+    @property
+    def extra_state_attributes(self):
+        """Return entity specific state attributes."""
+        if not self.available:
+            return {}
+
+        attrs = {}
+
+        # Split codec and virtualizer with channel format
+        if self.coordinator.data.get("audio_codec"):
+            codec_full = self.coordinator.data["audio_codec"]
+
+            # Split codec and virtualizer
+            codec_name = codec_full.split(" - ")[0] if " - " in codec_full else codec_full
+            virtualizer_name = codec_full.split(" - ")[1] if " - " in codec_full else "Direct"
+
+            # Helper to format channel count
+            def format_channels(count):
+                channel_map = {2: "2.0", 6: "5.1", 8: "5.1.2"}
+                return channel_map.get(count, str(count)) if count is not None else None
+
+            # Add codec with source channel format
+            stream_channels = self.coordinator.data.get("stream_channels")
+            if stream_channels is not None and stream_channels > 0:
+                channel_format = format_channels(stream_channels)
+                attrs["audio_codec"] = f"{codec_name} {channel_format}" if channel_format else codec_name
+            else:
+                attrs["audio_codec"] = codec_name
+
+            # Add virtualizer with playback channel format
+            audio_channels = self.coordinator.data.get("audio_channels")
+            if audio_channels is not None:
+                channel_format = format_channels(audio_channels)
+                attrs["audio_virtualizer"] = f"{virtualizer_name} {channel_format}" if channel_format else virtualizer_name
+            else:
+                attrs["audio_virtualizer"] = virtualizer_name
+
+        # Sample rate
+        if self.coordinator.data.get("sample_rate"):
+            attrs["sample_rate"] = self.coordinator.data["sample_rate"]
+
+        # Streaming service ID (e.g., "airplay", "spotify")
+        if self.coordinator.data.get("streaming_service"):
+            attrs["streaming_service"] = self.coordinator.data["streaming_service"]
+
+        # WiFi BSSID (access point MAC address)
+        if self.coordinator.data.get("wifi_bssid"):
+            attrs["wifi_bssid"] = self.coordinator.data["wifi_bssid"]
+
+        return attrs
 
     @property
     def supported_features(self):
@@ -331,124 +372,70 @@ class KefSpeaker(MediaPlayerEntity):
 
         return support_kef
 
-    async def async_update(self):
-        """Update latest state."""
-
-        # Update name and unique_id if needed (the first time)
-        if self.name is None:
-            self._name = await self._speaker.speaker_name
-        if self.unique_id is None:
-            self._attr_unique_id = (
-                f"{UNIQUE_ID_PREFIX}_{format_mac(await self._speaker.mac_address)}"
-            )
-
-        # Get speaker volume (from [0,100] to [0,1])
-        self._volume = await self._speaker.volume / 100
-
-        # Get speaker state.
-        # Playing/Idle is available only for bluetooth or wifi
-        spkr_source = await self._speaker.source
-        if await self._speaker.status == "standby":
-            self._state = STATE_OFF
-        elif spkr_source in ["wifi", "bluetooth"]:
-            if await self._speaker.is_playing:
-                self._state = STATE_PLAYING
-            elif self._attr_media_title is not None:
-                self._state = STATE_PAUSED
-            else:
-                self._state = STATE_IDLE
-        else:
-            self._state = STATE_ON
-
-        # Check if speaker is muted
-        self._muted = True if self._volume == 0 else False
-
-        # Get currently playing media info (if any)
-        media_dict = await self._speaker.get_song_information()
-        self._attr_media_title = media_dict["title"]
-        self._attr_media_artist = media_dict["artist"]
-        self._attr_media_album_name = media_dict["album"]
-        self._attr_media_image_url = media_dict["cover_url"]
-
-        # Get speaker source
-        self._source = await self._speaker.source
-        # Store current source as previous source
-        # if source is a real physical source
-        if self._source in self._sources:
-            self._previous_source = self._source
-
-        # Update media state if a media is playing
-        if self._state == STATE_PLAYING:
-            # Update media length
-            self._attr_media_duration = int(await self._speaker.song_length / 1000)
-            # Update media position
-            self._attr_media_position = int(await self._speaker.song_status / 1000)
-            # Update last media position update
-            self._attr_media_position_updated_at = dt_util.utcnow()
-        else:
-            # Set values to None if no media is playing
-            self._attr_media_duration = None
-            self._attr_media_position = None
-            self._attr_media_position_updated_at = None
-
     @delay_update(5)
     async def async_turn_on(self):
         """Turn the media player on."""
-        await self._speaker.set_source(self._previous_source)
+        await self.coordinator.speaker.set_source(self._previous_source)
 
     @delay_update(5)
     async def async_turn_off(self):
         """Turn the media player off."""
-        await self._speaker.shutdown()
+        await self.coordinator.speaker.shutdown()
 
     async def async_volume_up(self):
         """Volume up the media player."""
-        await self._speaker.set_volume(await self._speaker.volume + self._volume_step)
+        current_volume = await self.coordinator.speaker.volume
+        await self.coordinator.speaker.set_volume(current_volume + self._volume_step)
+        await self.coordinator.async_request_refresh()
 
     async def async_volume_down(self):
         """Volume down the media player."""
-        await self._speaker.set_volume(await self._speaker.volume - self._volume_step)
+        current_volume = await self.coordinator.speaker.volume
+        await self.coordinator.speaker.set_volume(current_volume - self._volume_step)
+        await self.coordinator.async_request_refresh()
 
     async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         # make sure volume is not louder than max_volume
         # multiply by 100 to be in range of what KefAsyncConnector expects
         volume = int(min(volume, self._max_volume) * 100)
-        await self._speaker.set_volume(volume)
+        await self.coordinator.speaker.set_volume(volume)
+        await self.coordinator.async_request_refresh()
 
     async def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
         if mute:
-            await self._speaker.mute()
+            await self.coordinator.speaker.mute()
         else:
-            await self._speaker.unmute()
+            await self.coordinator.speaker.unmute()
+        await self.coordinator.async_request_refresh()
 
     @delay_update(0.5)
     async def async_select_source(self, source):
         """Select input source."""
-        await self._speaker.set_source(source)
+        await self.coordinator.speaker.set_source(source)
 
     @delay_update(0.25)
     async def async_media_play(self):
         """Send play command."""
-        await self._speaker.toggle_play_pause()
+        await self.coordinator.speaker.toggle_play_pause()
 
     @delay_update(0.25)
     async def async_media_pause(self):
         """Send pause command."""
-        await self._speaker.toggle_play_pause()
+        await self.coordinator.speaker.toggle_play_pause()
 
     @delay_update(0.25)
     async def async_media_play_pause(self):
         """Toggle play pause."""
-        await self._speaker.toggle_play_pause()
+        await self.coordinator.speaker.toggle_play_pause()
 
     @delay_update(1.5)
     async def async_media_next_track(self):
         """Send next track command."""
-        await self._speaker.next_track()
+        await self.coordinator.speaker.next_track()
 
     @delay_update(1.5)
     async def async_media_previous_track(self):
         """Send previous track command."""
-        await self._speaker.previous_track()
+        await self.coordinator.speaker.previous_track()

--- a/custom_components/kef_connector/media_player.py
+++ b/custom_components/kef_connector/media_player.py
@@ -74,14 +74,14 @@ async def async_setup_entry(
     # Get config
     name = entry.data[CONF_NAME]
     host = entry.data[CONF_HOST]
-    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSXII").upper()
 
     # Get options with defaults
     max_volume = entry.options.get(CONF_MAX_VOLUME, DEFAULT_MAX_VOLUME)
     volume_step = entry.options.get(CONF_VOLUME_STEP, DEFAULT_VOLUME_STEP)
 
     # Get sources for this model
-    sources = SOURCES.get(speaker_model, SOURCES["LSX2"])
+    sources = SOURCES.get(speaker_model, SOURCES["LSXII"])
 
     # Get unique_id from coordinator speaker
     mac_address = format_mac(await coordinator.speaker.mac_address)

--- a/custom_components/kef_connector/media_player.py
+++ b/custom_components/kef_connector/media_player.py
@@ -400,6 +400,7 @@ class KefSpeaker(CoordinatorEntity, MediaPlayerEntity):
     @delay_update(5)
     async def async_turn_on(self):
         """Turn the media player on."""
+        await self.coordinator.speaker.power_on()
         await self.coordinator.speaker.set_source(self._previous_source)
 
     @delay_update(5)

--- a/custom_components/kef_connector/pykefcontrol
+++ b/custom_components/kef_connector/pykefcontrol
@@ -1,0 +1,1 @@
+/share/github/pykefcontrol/pykefcontrol

--- a/custom_components/kef_connector/sensor.py
+++ b/custom_components/kef_connector/sensor.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     # Get device info to group sensors under the same device as media_player
     name = entry.data[CONF_NAME]
     host = entry.data[CONF_HOST]
-    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSXII").upper()
     mac_address = format_mac(await coordinator.speaker.mac_address)
     device_unique_id = f"{UNIQUE_ID_PREFIX}_{mac_address}"
 

--- a/custom_components/kef_connector/sensor.py
+++ b/custom_components/kef_connector/sensor.py
@@ -1,0 +1,274 @@
+"""Sensor platform for KEF Connector integration."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    CONF_SPEAKER_MODEL,
+    DOMAIN,
+    MANUFACTURER,
+    MODEL_NAMES,
+    UNIQUE_ID_PREFIX,
+)
+from .coordinator import KefCoordinator
+
+
+def _format_channels(channel_count: int | None) -> str | None:
+    """Convert channel count to audio format notation.
+
+    Args:
+        channel_count: Number of audio channels
+
+    Returns:
+        Formatted string like "2.0", "5.1", "5.1.2" or the count as string
+    """
+    if channel_count is None:
+        return None
+
+    channel_map = {
+        2: "2.0",
+        6: "5.1",
+        8: "5.1.2",
+    }
+    return channel_map.get(channel_count, str(channel_count))
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up KEF Connector sensor entities from config entry."""
+    coordinator: KefCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Get device info to group sensors under the same device as media_player
+    name = entry.data[CONF_NAME]
+    host = entry.data[CONF_HOST]
+    speaker_model = entry.data.get(CONF_SPEAKER_MODEL, "LSX2").upper()
+    mac_address = format_mac(await coordinator.speaker.mac_address)
+    device_unique_id = f"{UNIQUE_ID_PREFIX}_{mac_address}"
+
+    # Build device_info that matches media_player
+    device_info = {
+        "identifiers": {(DOMAIN, device_unique_id)},
+        "name": name,
+        "manufacturer": MANUFACTURER,
+        "model": MODEL_NAMES.get(speaker_model, f"KEF {speaker_model}"),
+        "connections": {("ip", host)},
+    }
+
+    # Create sensor entities with shared device_info
+    # Only create codec sensors for XIO model (has HDMI/TV inputs)
+    entities = []
+
+    # Codec sensors - only for XIO
+    if speaker_model == "XIO":
+        entities.extend([
+            KefCodecSensor(coordinator, entry, name, device_info),
+            KefVirtualizerSensor(coordinator, entry, name, device_info),
+            KefSampleRateSensor(coordinator, entry, name, device_info),
+        ])
+
+    # WiFi sensors - all models
+    entities.extend([
+        KefWiFiSignalSensor(coordinator, entry, name, device_info),
+        KefWiFiFrequencySensor(coordinator, entry, name, device_info),
+    ])
+
+    async_add_entities(entities)
+
+
+class KefCodecSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for KEF audio codec (part before '-')."""
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} Audio Codec"
+        self._attr_unique_id = f"{entry.entry_id}_audio_codec"
+        self._attr_icon = "mdi:waveform"
+        self._attr_device_info = device_info
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the audio codec with channel format (e.g., 'Dolby Digital Plus 5.1')."""
+        if not self.coordinator.last_update_success:
+            return None
+
+        codec_full = self.coordinator.data.get("audio_codec")
+        if not codec_full:
+            return None
+
+        # Split on " - " and get codec part (before '-')
+        codec_name = codec_full.split(" - ")[0] if " - " in codec_full else codec_full
+
+        # Append channel format from stream_channels (source channels)
+        stream_channels = self.coordinator.data.get("stream_channels")
+        if stream_channels is not None and stream_channels > 0:
+            channel_format = _format_channels(stream_channels)
+            if channel_format:
+                return f"{codec_name} {channel_format}"
+
+        return codec_name
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("audio_codec") is not None
+        )
+
+
+class KefVirtualizerSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for KEF audio virtualizer (part after '-')."""
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} Audio Virtualizer"
+        self._attr_unique_id = f"{entry.entry_id}_audio_virtualizer"
+        self._attr_icon = "mdi:surround-sound"
+        self._attr_device_info = device_info
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the audio virtualizer with channel format (e.g., 'Dolby Surround 5.1.2')."""
+        if not self.coordinator.last_update_success:
+            return None
+
+        codec_full = self.coordinator.data.get("audio_codec")
+        if not codec_full:
+            return None
+
+        # Split on " - " and get virtualizer part (after '-'), or "Direct" if not present
+        virtualizer_name = codec_full.split(" - ")[1] if " - " in codec_full else "Direct"
+
+        # Append channel format from audio_channels (playback channels)
+        audio_channels = self.coordinator.data.get("audio_channels")
+        if audio_channels is not None:
+            channel_format = _format_channels(audio_channels)
+            if channel_format:
+                return f"{virtualizer_name} {channel_format}"
+
+        return virtualizer_name
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("audio_codec") is not None
+        )
+
+
+class KefSampleRateSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for KEF audio sample rate."""
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} Audio Sample Rate"
+        self._attr_unique_id = f"{entry.entry_id}_sample_rate"
+        self._attr_native_unit_of_measurement = "Hz"
+        self._attr_icon = "mdi:sine-wave"
+        self._attr_device_info = device_info
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the sample rate in Hz."""
+        if not self.coordinator.last_update_success:
+            return None
+        return self.coordinator.data.get("sample_rate")
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("sample_rate") is not None
+        )
+
+
+class KefWiFiSignalSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for KEF WiFi signal strength (disabled by default)."""
+
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} WiFi Signal"
+        self._attr_unique_id = f"{entry.entry_id}_wifi_signal"
+        self._attr_native_unit_of_measurement = "dBm"
+        self._attr_icon = "mdi:wifi"
+        self._attr_device_info = device_info
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the WiFi signal strength in dBm."""
+        if not self.coordinator.last_update_success:
+            return None
+        return self.coordinator.data.get("wifi_signal_strength")
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("wifi_signal_strength") is not None
+        )
+
+
+class KefWiFiFrequencySensor(CoordinatorEntity, SensorEntity):
+    """Sensor for KEF WiFi frequency band (disabled by default)."""
+
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} WiFi Frequency"
+        self._attr_unique_id = f"{entry.entry_id}_wifi_frequency"
+        self._attr_icon = "mdi:wifi-settings"
+        self._attr_device_info = device_info
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the WiFi frequency band (2.4 GHz or 5 GHz)."""
+        if not self.coordinator.last_update_success:
+            return None
+
+        freq = self.coordinator.data.get("wifi_frequency")
+        if freq is None:
+            return None
+
+        # Convert frequency to band display
+        if freq < 3000:
+            return "2.4 GHz"
+        else:
+            return f"{freq / 1000:.1f} GHz"
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("wifi_frequency") is not None
+        )

--- a/custom_components/kef_connector/sensor.py
+++ b/custom_components/kef_connector/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -73,6 +74,9 @@ async def async_setup_entry(
             KefCodecSensor(coordinator, entry, name, device_info),
             KefVirtualizerSensor(coordinator, entry, name, device_info),
             KefSampleRateSensor(coordinator, entry, name, device_info),
+            KefRawCodecSensor(coordinator, entry, name, device_info),
+            KefStreamChannelsSensor(coordinator, entry, name, device_info),
+            KefAudioChannelsSensor(coordinator, entry, name, device_info),
         ])
 
     # WiFi sensors - all models
@@ -110,13 +114,18 @@ class KefCodecSensor(CoordinatorEntity, SensorEntity):
         # Split on " - " and get codec part (before '-')
         codec_name = codec_full.split(" - ")[0] if " - " in codec_full else codec_full
 
-        # Append channel format from stream_channels (source channels)
+        # Strip "Dolby " prefix from PCM (but NOT from "Dolby Digital" or "Dolby Digital Plus")
+        if codec_name == "Dolby PCM":
+            codec_name = "PCM"
+
+        # Append channel format from stream_channels (source/input channels)
         stream_channels = self.coordinator.data.get("stream_channels")
         if stream_channels is not None and stream_channels > 0:
             channel_format = _format_channels(stream_channels)
             if channel_format:
                 return f"{codec_name} {channel_format}"
 
+        # Fallback: just return codec name without channel count
         return codec_name
 
     @property
@@ -154,13 +163,24 @@ class KefVirtualizerSensor(CoordinatorEntity, SensorEntity):
         # Split on " - " and get virtualizer part (after '-'), or "Direct" if not present
         virtualizer_name = codec_full.split(" - ")[1] if " - " in codec_full else "Direct"
 
-        # Append channel format from audio_channels (playback channels)
-        audio_channels = self.coordinator.data.get("audio_channels")
-        if audio_channels is not None:
-            channel_format = _format_channels(audio_channels)
+        # For Direct mode: use INPUT channels (stream_channels), fallback to OUTPUT channels
+        # For virtualizer modes: use fixed 8 channels (5.1.2) since API returns garbage
+        if virtualizer_name == "Direct":
+            # Direct mode - use input channels, fallback to output if input unknown
+            channels = self.coordinator.data.get("stream_channels")
+            if channels is None or channels == 0:
+                # Fallback to playback channels (e.g., Dolby Atmos with unknown input)
+                channels = self.coordinator.data.get("audio_channels")
+        else:
+            # Virtualizer active - hardcode to 8 (5.1.2) for XIO
+            channels = 8
+
+        if channels is not None and channels > 0:
+            channel_format = _format_channels(channels)
             if channel_format:
                 return f"{virtualizer_name} {channel_format}"
 
+        # Fallback: just return virtualizer name without channel count
         return virtualizer_name
 
     @property
@@ -181,7 +201,7 @@ class KefSampleRateSensor(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_name = f"{name} Audio Sample Rate"
-        self._attr_unique_id = f"{entry.entry_id}_sample_rate"
+        self._attr_unique_id = f"{entry.entry_id}_audio_sample_rate"
         self._attr_native_unit_of_measurement = "Hz"
         self._attr_icon = "mdi:sine-wave"
         self._attr_device_info = device_info
@@ -199,6 +219,102 @@ class KefSampleRateSensor(CoordinatorEntity, SensorEntity):
         return (
             self.coordinator.last_update_success
             and self.coordinator.data.get("sample_rate") is not None
+        )
+
+
+class KefRawCodecSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for raw/unparsed audio codec string from API."""
+
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} Audio Codec Raw"
+        self._attr_unique_id = f"{entry.entry_id}_audio_codec_raw"
+        self._attr_icon = "mdi:information-outline"
+        self._attr_device_info = device_info
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the raw codec string without any processing."""
+        if not self.coordinator.last_update_success:
+            return None
+        return self.coordinator.data.get("audio_codec_raw")
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("audio_codec_raw") is not None
+        )
+
+
+class KefStreamChannelsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for source/input audio channels from API (diagnostic, disabled by default)."""
+
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} Audio Source Channels"
+        self._attr_unique_id = f"{entry.entry_id}_stream_channels"
+        self._attr_icon = "mdi:audio-input-stereo-minijack"
+        self._attr_device_info = device_info
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the source channel count from API (streamChannels field)."""
+        if not self.coordinator.last_update_success:
+            return None
+        return self.coordinator.data.get("stream_channels")
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("stream_channels") is not None
+        )
+
+
+class KefAudioChannelsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for playback/output audio channels from API (diagnostic, disabled by default)."""
+
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self, coordinator: KefCoordinator, entry: ConfigEntry, name: str, device_info: dict
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_name = f"{name} Audio Playback Channels"
+        self._attr_unique_id = f"{entry.entry_id}_audio_channels"
+        self._attr_icon = "mdi:speaker-multiple"
+        self._attr_device_info = device_info
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the playback channel count from API (nrAudioChannels field)."""
+        if not self.coordinator.last_update_success:
+            return None
+        return self.coordinator.data.get("audio_channels")
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get("audio_channels") is not None
         )
 
 

--- a/custom_components/kef_connector/translations/en.json
+++ b/custom_components/kef_connector/translations/en.json
@@ -1,0 +1,83 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up KEF Speaker",
+        "description": "Configure your KEF speaker manually by IP address",
+        "data": {
+          "host": "IP Address",
+          "speaker_model": "Speaker Model",
+          "scan_interval": "Scan Interval (seconds)",
+          "offline_retry_interval": "Offline Retry Interval (seconds)",
+          "volume_step": "Volume Step",
+          "maximum_volume": "Maximum Volume"
+        },
+        "data_description": {
+          "host": "The IP address of your KEF speaker",
+          "speaker_model": "Determines available input sources. Auto-detected from Google Cast name.",
+          "scan_interval": "How often to update speaker status when online. Lower = more responsive, higher = less network traffic. (5-300 seconds)",
+          "offline_retry_interval": "How often to check if an offline speaker is back online. Higher values reduce log spam. (30-600 seconds)",
+          "volume_step": "Volume change per up/down command. 0.05 = 5% per step. (0.01-0.10)",
+          "maximum_volume": "Safety limit to prevent accidental loud volume. 1.0 = 100% maximum. (0.1-1.0)"
+        }
+      },
+      "zeroconf_confirm": {
+        "title": "Discovered KEF Speaker: {name}",
+        "description": "Auto-discovered on your network at {host}. Verify settings below.",
+        "data": {
+          "speaker_model": "Speaker Model",
+          "scan_interval": "Scan Interval (seconds)",
+          "offline_retry_interval": "Offline Retry Interval (seconds)",
+          "volume_step": "Volume Step",
+          "maximum_volume": "Maximum Volume"
+        },
+        "data_description": {
+          "speaker_model": "Determines available input sources. Auto-detected from Google Cast name.",
+          "scan_interval": "How often to update speaker status when online. Lower = more responsive, higher = less network traffic. (5-300 seconds)",
+          "offline_retry_interval": "How often to check if an offline speaker is back online. Higher values reduce log spam. (30-600 seconds)",
+          "volume_step": "Volume change per up/down command. 0.05 = 5% per step. (0.01-0.10)",
+          "maximum_volume": "Safety limit to prevent accidental loud volume. 1.0 = 100% maximum. (0.1-1.0)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the KEF speaker. Please check the IP address and ensure the speaker is powered on and connected to your network."
+    },
+    "abort": {
+      "already_configured": "This KEF speaker is already configured.",
+      "cannot_connect": "Could not connect to the KEF speaker.",
+      "not_kef_device": "Device is not a KEF speaker."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "KEF Speaker Options",
+        "description": "Configure advanced settings for your KEF speaker",
+        "data": {
+          "scan_interval": "Scan Interval (seconds)",
+          "offline_retry_interval": "Offline Retry Interval (seconds)",
+          "volume_step": "Volume Step",
+          "maximum_volume": "Maximum Volume"
+        },
+        "data_description": {
+          "scan_interval": "How often to update speaker status when online. Lower = more responsive, higher = less network traffic. (5-300 seconds)",
+          "offline_retry_interval": "How often to check if an offline speaker is back online. Higher values reduce log spam. (30-600 seconds)",
+          "volume_step": "Volume change per up/down command. 0.05 = 5% per step. (0.01-0.10)",
+          "maximum_volume": "Safety limit to prevent accidental loud volume. 1.0 = 100% maximum. (0.1-1.0)"
+        }
+      }
+    }
+  },
+  "selector": {
+    "speaker_model": {
+      "options": {
+        "LSX2": "KEF LSX II (Wi-Fi, Bluetooth, TV, Optical, Analog, USB)",
+        "LSX2LT": "KEF LSX II LT (Wi-Fi, Bluetooth, TV, Optical, USB)",
+        "LS50W2": "KEF LS50 Wireless II (Wi-Fi, Bluetooth, TV, Optical, Coaxial, Analog)",
+        "LS60": "KEF LS60 Wireless (Wi-Fi, Bluetooth, TV, Optical, Coaxial, Analog)",
+        "XIO": "KEF XIO (Wi-Fi, Bluetooth, TV, Optical)"
+      }
+    }
+  }
+}

--- a/custom_components/kef_connector/translations/en.json
+++ b/custom_components/kef_connector/translations/en.json
@@ -72,10 +72,10 @@
   "selector": {
     "speaker_model": {
       "options": {
-        "LSX2": "KEF LSX II (Wi-Fi, Bluetooth, TV, Optical, Analog, USB)",
-        "LSX2LT": "KEF LSX II LT (Wi-Fi, Bluetooth, TV, Optical, USB)",
-        "LS50W2": "KEF LS50 Wireless II (Wi-Fi, Bluetooth, TV, Optical, Coaxial, Analog)",
-        "LS60": "KEF LS60 Wireless (Wi-Fi, Bluetooth, TV, Optical, Coaxial, Analog)",
+        "LSXII": "KEF LSX II (Wi-Fi, Bluetooth, TV, Optical, Analog, USB)",
+        "LSXIILT": "KEF LSX II LT (Wi-Fi, Bluetooth, TV, Optical, USB)",
+        "LS50WII": "KEF LS50 Wireless II (Wi-Fi, Bluetooth, TV, Optical, Coaxial, Analog)",
+        "LS60Wireless": "KEF LS60 Wireless (Wi-Fi, Bluetooth, TV, Optical, Coaxial, Analog)",
         "XIO": "KEF XIO (Wi-Fi, Bluetooth, TV, Optical)"
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "Kef Connector",
+    "name": "KEF Connector",
     "render_readme": true
 }


### PR DESCRIPTION
Replaces YAML configuration with a UI-based Config Flow setup.

## Changes

- **Config Flow** — UI-based setup replacing `configuration.yaml`. Supports manual entry and zeroconf auto-discovery (filters non-KEF devices).
- **Options flow** — Configurable scan interval, offline retry interval, max volume, and volume step.
- **Coordinator** — DataUpdateCoordinator with failure tolerance: 3 consecutive failures before marking offline, cached data returned during transient issues, slower retry interval when offline.
- **WiFi sensors** — Signal strength, SSID, frequency (all models).
- **Codec/audio sensors** — Audio codec, sample rate, channel count (XIO only).
- **Bug fixes** — Close aiohttp session on failure to prevent corrupted connection pool; gate codec info fetch to XIO only (other models only support LPCM).

## Tested on
- KEF LSX II, LSX II LT, XIO Soundbar
- Manual setup and zeroconf auto-discovery
- Failure tolerance (offline/online transitions)
- Codec detection: PCM 2.0/5.1, Dolby Digital 5.1, Dolby Atmos