### PR TITLE
Next version should be 0.6.4

### DIFF
--- a/custom_components/kef_connector/manifest.json
+++ b/custom_components/kef_connector/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pykefcontrol==0.9.1"
   ],
-  "version":"0.6.0"
+  "version":"0.6.4"
 }


### PR DESCRIPTION
Version number wasn't incremented in recent updates. I just spent 30 minutes tearing my hair out as to why I had done several updates, but the HASS UI still showed version 0.6.0.

Incrementing the release number as soon as the previous release is cut is safest